### PR TITLE
Inject discovered input filter into MvcEvent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         "zfcampus/zf-api-problem": "~1.0-dev",
         "zfcampus/zf-content-negotiation": "~1.0-dev"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=3.7.0"
+    },
     "autoload": {
         "psr-0": {
             "ZF\\ContentValidation\\": "src/",

--- a/src/ZF/ContentValidation/ContentValidationListener.php
+++ b/src/ZF/ContentValidation/ContentValidationListener.php
@@ -75,7 +75,8 @@ class ContentValidationListener implements ListenerAggregateInterface
      * Attempt to validate the incoming request
      *
      * If an input filter is associated with the matched controller service,
-     * attempt to validate the incoming request.
+     * attempt to validate the incoming request, and inject the event with the
+     * input filter, as the "ZF\ContentValidation\InputFilter" parameter.
      *
      * Uses the ContentNegotiation ParameterDataContainer to retrieve parameters
      * to validate, and returns an ApiProblemResponse when validation fails.
@@ -134,6 +135,7 @@ class ContentValidationListener implements ListenerAggregateInterface
         $data = $dataContainer->getBodyParams();
 
         $inputFilter = $this->getInputFilter($inputFilterService);
+        $e->setParam('ZF\ContentValidation\InputFilter', $inputFilter);
 
         if ($request->isPatch()) {
             try {

--- a/test/ZFTest/ContentValidation/ContentValidationListenerTest.php
+++ b/test/ZFTest/ContentValidation/ContentValidationListenerTest.php
@@ -206,6 +206,7 @@ class ContentValidationListenerTest extends TestCase
 
         $this->assertNull($listener->onRoute($event));
         $this->assertNull($event->getResponse());
+        return $event;
     }
 
     public function testReturnsApiProblemResponseIfContentIsInvalid()
@@ -417,5 +418,14 @@ class ContentValidationListenerTest extends TestCase
     public function testInvalidValidationGroupIs400Response($response)
     {
         $this->assertEquals(400, $response->getApiProblem()->httpStatus);
+    }
+
+    /**
+     * @depends testReturnsNothingIfContentIsValid
+     */
+    public function testInputFilterIsInjectedIntoMvcEvent($event)
+    {
+        $inputFilter = $event->getParam('ZF\ContentValidation\InputFilter');
+        $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter);
     }
 }


### PR DESCRIPTION
- Once an input filter is discovered, it is now injected into the
  MvcEvent as the `ZF\ContentValidation\InputFilter` parameter, allowing
  retrieval later.
- Helps to address zfcampus/zf-apigility-admin#46
