### PR TITLE
Return indicator of what field is bad in a PATCH request back to the caller of the API

### DIFF
--- a/src/ZF/ContentValidation/ContentValidationListener.php
+++ b/src/ZF/ContentValidation/ContentValidationListener.php
@@ -144,8 +144,16 @@ class ContentValidationListener implements ListenerAggregateInterface
             try {
                 $inputFilter->setValidationGroup(array_keys($data));
             } catch (InputFilterInvalidArgumentException $ex) {
+                $pattern = '/expects a list of valid input names; "(?P<field>[^"]+)" was not found/';
+                $matched = preg_match($pattern, $ex->getMessage(), $matches);
+                if (!$matched) {
+                    return new ApiProblemResponse(
+                        new ApiProblem(400, $ex)
+                    );
+                }
+
                 return new ApiProblemResponse(
-                    new ApiProblem(400, 'Invalid data specified in request')
+                    new ApiProblem(422, 'Unrecognized field "' . $matches['field'] . '"')
                 );
             }
         }


### PR DESCRIPTION
The idea here is to get a useful bit of information back to the user about what field is invalid. Unfortunately because the input filter throws an exception on the first invalid field, I cannot get more than one invalid field returned.
