### PR TITLE
Fallback on InputFilterManager service

### DIFF
--- a/src/ZF/ContentValidation/ContentValidationListener.php
+++ b/src/ZF/ContentValidation/ContentValidationListener.php
@@ -223,18 +223,15 @@ class ContentValidationListener implements ListenerAggregateInterface
             return true;
         }
 
-        if (! $this->services
-            || ! $this->services->has($inputFilterService)
-        ) {
+        if (!$this->services || !$this->services->has($inputFilterService)) {
             return false;
         }
 
         $inputFilter = $this->services->get($inputFilterService);
-        if (! $inputFilter instanceof InputFilterInterface) {
+        if (!$inputFilter instanceof InputFilterInterface) {
             return false;
         }
 
-        $this->inputFilters[$inputFilterService] = $inputFilter;
         return true;
     }
 
@@ -246,6 +243,16 @@ class ContentValidationListener implements ListenerAggregateInterface
      */
     protected function getInputFilter($inputFilterService)
     {
+        if (!isset($this->inputFilters[$inputFilterService])) {
+            $inputFilter = $this->services->get($inputFilterService);
+            if (!$inputFilter instanceof InputFilterInterface) {
+                throw new InputFilterInvalidArgumentException(
+                    'An input filter by the name ' . $inputFilterService . ' does not exist.'
+                );
+            }
+            $this->inputFilters[$inputFilterService] = $inputFilter;
+        }
+
         return $this->inputFilters[$inputFilterService];
     }
 }

--- a/src/ZF/ContentValidation/InputFilter/InputFilterAbstractServiceFactory.php
+++ b/src/ZF/ContentValidation/InputFilter/InputFilterAbstractServiceFactory.php
@@ -35,7 +35,11 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
         if (!isset($config['input_filters'][$rName])
             || !is_array($config['input_filters'][$rName])
         ) {
-            return false;
+            /** @var \Zend\InputFilter\InputFilterPluginManager $inputFactoryManager */
+            $inputFactoryManager = $services->get('InputFilterManager');
+            if (!$inputFactoryManager->has(array($cName, $rName))) {
+                return false;
+            }
         }
 
         return true;
@@ -50,11 +54,16 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
     public function createServiceWithName(ServiceLocatorInterface $services, $cName, $rName)
     {
         $allConfig = $services->get('Config');
-        $config    = $allConfig['input_filters'][$rName];
 
-        $factory   = $this->getInputFilterFactory($services);
+        if (isset($allConfig['input_filters'][$rName])) {
+            $config = $allConfig['input_filters'][$rName];
+            $factory = $this->getInputFilterFactory($services);
+            return $factory->createInputFilter($config);
+        }
 
-        return $factory->createInputFilter($config);
+        /** @var \Zend\InputFilter\InputFilterPluginManager $inputFactoryManager */
+        $inputFactoryManager = $services->get('InputFilterManager');
+        return $inputFactoryManager->create($cName);
     }
 
     protected function getInputFilterFactory(ServiceLocatorInterface $services)

--- a/test/ZFTest/ContentValidation/InputFilter/InputFilterAbstractServiceFactoryTest.php
+++ b/test/ZFTest/ContentValidation/InputFilter/InputFilterAbstractServiceFactoryTest.php
@@ -14,9 +14,15 @@ use ZF\ContentValidation\InputFilter\InputFilterAbstractServiceFactory;
 
 class InputFilterAbstractFactoryTest extends TestCase
 {
+    /** @var ServiceManager */
+    protected $services;
+    /** @var InputFilterAbstractServiceFactory */
+    protected $factory;
+
     public function setUp()
     {
         $this->services = new ServiceManager();
+        $this->services->setService('InputFilterManager', $this->getMock('Zend\InputFilter\InputFilterPluginManager'));
         $this->factory = new InputFilterAbstractServiceFactory();
     }
 


### PR DESCRIPTION
Modify the abstract service factory to use the InputFilterManager service when a configuration is not found.  This is important to make content-validation specific wiring be able to use normal input_filters setups (invokables, etc);
