### PR TITLE
Ensure files are merged with data prior to validation

### DIFF
--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -153,6 +153,11 @@ class ContentValidationListener implements ListenerAggregateInterface
             $data = array();
         }
 
+        $files = $request->getFiles();
+        if (0 < count($files)) {
+            $data = array_merge_recursive($data, $files->toArray());
+        }
+
         $inputFilter = $this->getInputFilter($inputFilterService);
         $e->setParam('ZF\ContentValidation\InputFilter', $inputFilter);
 


### PR DESCRIPTION
Modified the ContentValidationListener to check if the request has any upload files present; if so, it will merge that metadata with the incoming parameter data prior to passing that data to the composed input filter.
