### PR TITLE
isCollection() method returning true for entities

### DIFF
--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -303,7 +303,7 @@ class ContentValidationListener implements ListenerAggregateInterface
 
         $identifierName = $this->restControllers[$serviceName];
         if ($matches->getParam($identifierName)) {
-            return true;
+            return false;
         }
 
         return (null === $request->getQuery($identifierName, null));


### PR DESCRIPTION
As noted on the [mailing list](https://groups.google.com/a/zend.com/d/msgid/apigility-users/c4cfcb3e-6e99-4ee1-9968-080f8abb5096%40zend.com), the logic for determining whether to validate an incoming request as a collection or as an entity is currently broken.

The error appears to be on line 306; when the identifier is found in the route matches, we should be returning `false`.
