### PR TITLE
Bug: Validation bypassed when POST is empty

### DIFF
--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -297,7 +297,7 @@ class ContentValidationListener implements ListenerAggregateInterface
             return false;
         }
 
-        if ($request->isPost() && ArrayUtils::isHashTable($data)) {
+        if ($request->isPost() && (empty($data) || ArrayUtils::isHashTable($data))) {
             return false;
         }
 

--- a/test/ContentValidationListenerTest.php
+++ b/test/ContentValidationListenerTest.php
@@ -1101,4 +1101,52 @@ class ContentValidationListenerTest extends TestCase
         $this->assertNull($listener->onRoute($event));
         $this->assertNull($event->getResponse());
     }
+
+    /**
+     * @group 20
+     */
+    public function testEmptyPostShouldReturnValidationError()
+    {
+        $services = new ServiceManager();
+        $factory  = new InputFilterFactory();
+        $services->setService('FooValidator', $factory->createInputFilter(array(
+            'foo' => array(
+                'name' => 'foo',
+                'validators' => array(
+                    array('name' => 'Digits'),
+                ),
+            ),
+            'bar' => array(
+                'name' => 'bar',
+                'validators' => array(
+                    array(
+                        'name'    => 'Regex',
+                        'options' => array('pattern' => '/^[a-z]+/i'),
+                    ),
+                ),
+            ),
+        )));
+        $listener = new ContentValidationListener(array(
+            'Foo' => array('input_filter' => 'FooValidator'),
+        ), $services, array(
+            'Foo' => 'foo_id',
+        ));
+
+        $request = new HttpRequest();
+        $request->setMethod('POST');
+
+        $matches = new RouteMatch(array('controller' => 'Foo'));
+
+        $dataParams = new ParameterDataContainer();
+        $dataParams->setBodyParams(array());
+
+        $event   = new MvcEvent();
+        $event->setRequest($request);
+        $event->setRouteMatch($matches);
+        $event->setParam('ZFContentNegotiationParameterData', $dataParams);
+
+        $response = $listener->onRoute($event);
+        $this->assertInstanceOf('ZF\ApiProblem\ApiProblemResponse', $response);
+        $this->assertEquals(422, $response->getApiProblem()->status);
+    }
 }


### PR DESCRIPTION
I have a validator set up for one of my resources. `label` is a required field, `street` is optional. However, when I send an empty POST request, it completely ignores my validation rules, and passes the request to the controller. I end up with an MySQL error `Integrity constraint violation: 1048 Column 'label' cannot be null`

```
'Api\\V1\\Rest\\Address\\Validator' => array(
         array(
                'name' => 'street',
                'required' => false,
                'filters' => array(),
                'validators' => array(
                    0 => array(
                        'name' => 'Application\\Validator\\Text',
                        'options' => array(
                            'multiline' => false
                        ),
                    ),
                ),
                'description' => 'street name',
                'allow_empty' => true,
                'continue_if_empty' => true,
            ),
            array(
                'name' => 'label',
                'required' => true,
                'filters' => array(),
                'validators' => array(
                    array(
                        'name' => 'Application\\Validator\\Text',
                        'options' => array(
                            'multiline' => false
                        ),
                    ),
                ),
                'allow_empty' => false,
                'continue_if_empty' => false,
            )
     )
```

With httpie:
`http POST http://localhost/address`
