### PR TITLE
Updated getInputFilterFactory to reuse config

### DIFF
--- a/src/InputFilter/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilter/InputFilterAbstractServiceFactory.php
@@ -115,7 +115,10 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
      */
     protected function getInputFilterPluginManager(ServiceLocatorInterface $services)
     {
-        if ($services->has('InputFilterManager') && $services->has('FilterManager') && $services->has('ValidatorManager')) {
+        if ($services->has('InputFilterManager')
+            && $services->has('FilterManager')
+            && $services->has('ValidatorManager')
+        ) {
             return $services->get('InputFilterManager');
         }
 

--- a/src/InputFilter/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilter/InputFilterAbstractServiceFactory.php
@@ -8,6 +8,7 @@ namespace ZF\ContentValidation\InputFilter;
 
 use Zend\Filter\FilterPluginManager;
 use Zend\InputFilter\Factory;
+use Zend\InputFilter\InputFilterPluginManager;
 use Zend\ServiceManager\AbstractFactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Validator\ValidatorPluginManager;
@@ -71,7 +72,7 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
             return $this->factory;
         }
 
-        $this->factory = new Factory();
+        $this->factory = new Factory($this->getInputFilterPluginManager($services));
         $this->factory
             ->getDefaultFilterChain()
             ->setPluginManager($this->getFilterPluginManager($services));
@@ -106,5 +107,18 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         return new ValidatorPluginManager();
+    }
+
+    /**
+     * @param ServiceLocatorInterface $services
+     * @return \Zend\ServiceManager\AbstractPluginManager
+     */
+    protected function getInputFilterPluginManager(ServiceLocatorInterface $services)
+    {
+        if ($services->has('InputFilterManager')) {
+            return $services->get('InputFilterManager');
+        }
+
+        return new InputFilterPluginManager();
     }
 }

--- a/src/InputFilter/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilter/InputFilterAbstractServiceFactory.php
@@ -119,6 +119,6 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
             return $services->get('InputFilterManager');
         }
 
-        return new InputFilterPluginManager();
+        return null;
     }
 }

--- a/src/InputFilter/InputFilterAbstractServiceFactory.php
+++ b/src/InputFilter/InputFilterAbstractServiceFactory.php
@@ -115,7 +115,7 @@ class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
      */
     protected function getInputFilterPluginManager(ServiceLocatorInterface $services)
     {
-        if ($services->has('InputFilterManager')) {
+        if ($services->has('InputFilterManager') && $services->has('FilterManager') && $services->has('ValidatorManager')) {
             return $services->get('InputFilterManager');
         }
 


### PR DESCRIPTION
This reestablishes the association between input filters created with zf-content-validation and the original InputFilterPluginManager.

e.g. this allows the plugin to actually handle CollectionInputFilter in the config.