### PR TITLE
Resolves Issue #37 - Allow modification of InputFilter before validation

### DIFF
--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -240,7 +240,12 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
         });
 
         $last = $results->last();
-        if ($last instanceof ApiProblem || $last instanceof ApiProblemResponse) {
+
+        if ($last instanceof ApiProblem) {
+            $last = new ApiProblemResponse($last);
+        }
+
+        if ($last instanceof ApiProblemResponse) {
             return $last;
         }
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -233,15 +233,14 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
         $e->setParam('ZF\ContentValidation\InputFilter', $inputFilter);
 
         $events = $this->getEventManager();
-        $results = $events->trigger(self::EVENT_BEFORE_VALIDATE, $e, function($result){
+        $results = $events->trigger(self::EVENT_BEFORE_VALIDATE, $e, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
         });
+
         $last = $results->last();
-        if($last instanceof ApiProblem
-            || $last instanceof ApiProblemResponse
-        ) {
+        if ($last instanceof ApiProblem || $last instanceof ApiProblemResponse) {
             return $last;
         }
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -6,7 +6,9 @@
 
 namespace ZF\ContentValidation;
 
+use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\Http\Request as HttpRequest;
 use Zend\InputFilter\CollectionInputFilter;
@@ -20,12 +22,16 @@ use ZF\ApiProblem\ApiProblem;
 use ZF\ApiProblem\ApiProblemResponse;
 use ZF\ContentNegotiation\ParameterDataContainer;
 
-class ContentValidationListener implements ListenerAggregateInterface
+class ContentValidationListener implements ListenerAggregateInterface, EventManagerAwareInterface
 {
+    const EVENT_BEFORE_VALIDATE = 'contentvalidation.beforevalidate';
+
     /**
      * @var array
      */
     protected $config = array();
+
+    protected $events;
 
     /**
      * @var ServiceLocatorInterface
@@ -75,6 +81,42 @@ class ContentValidationListener implements ListenerAggregateInterface
         $this->config             = $config;
         $this->inputFilterManager = $inputFilterManager;
         $this->restControllers    = $restControllers;
+    }
+
+    /**
+     * Set event manager instance
+     *
+     * Sets the event manager identifiers to the current class, this class, and
+     * the resource interface.
+     *
+     * @param  EventManagerInterface $events
+     * @return ContentValidationListener
+     */
+    public function setEventManager(EventManagerInterface $events)
+    {
+        $events->addIdentifiers(array(
+            get_class($this),
+            __CLASS__,
+            self::EVENT_BEFORE_VALIDATE
+        ));
+        $this->events = $events;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve event manager
+     *
+     * Lazy-instantiates an EM instance if none provided.
+     *
+     * @return EventManagerInterface
+     */
+    public function getEventManager()
+    {
+        if (!$this->events) {
+            $this->setEventManager(new EventManager());
+        }
+        return $this->events;
     }
 
     /**
@@ -189,6 +231,19 @@ class ContentValidationListener implements ListenerAggregateInterface
         }
 
         $e->setParam('ZF\ContentValidation\InputFilter', $inputFilter);
+
+        $events = $this->getEventManager();
+        $results = $events->trigger(self::EVENT_BEFORE_VALIDATE, $e, function($result){
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
+        });
+        $last = $results->last();
+        if($last instanceof ApiProblem
+            || $last instanceof ApiProblemResponse
+        ) {
+            return $last;
+        }
 
         // We cannot create validation groups when validating collections, as
         // the values submitted may vary between each entity in the collection.


### PR DESCRIPTION
Example Usage:
```
use Zend\EventManager\SharedListenerAggregateInterface;
use Zend\Mvc\MvcEvent;
use Zend\Validator\Db\NoRecordExists;
use ZF\ContentValidation\ContentValidationListener

class SomeValidationListener implements SharedListenerAggregateInterface
{
    public function attachShared(SharedEventManagerInterface $events)
    {
        // trigger after authentication/authorization and content negotiation
        $this->listeners[] = $events->attach(
            'ZF\ContentValidation\ContentValidationListener',
            ZFValidationListener::EVENT_BEFORE_VALIDATE,
            array($this, 'beforeValidate')
        );
    }

    public function detachShared(SharedEventManagerInterface $events)
    {
        foreach ($this->listeners as $index => $callback) {
            if ($events->detach($callback)) {
                unset($this->listeners[$index]);
            }
        }
    }

    public function beforeValidate(MvcEvent $e)
    {
        if($e->getRequest()->getMethod() !== 'PUT') {
            return;
        }

        $matches = $e->getRouteMatch();
        $controller = $matches->getParam('controller', false);

        $inputFilter = $e->getParam('ZF\ContentValidation\InputFilter', false);
        if (! $inputFilter) {
            return;
        }

        // look for controllers of interest.
        switch($controller) {
            case 'CompanyAdmin\V1\Rest\Users\Controller':
                $id = $matches->getParam('user_id');
                break;
            default:
                return;
        }

        $input = $inputFilter->get('username');
        $chain = $input->getValidatorChain();

        foreach ($chain->getValidators() as $validator) {
            if (! $validator['instance'] instanceof NoRecordExists) {
                continue;
            }

            $validator['instance']->setExclude(array(
                'field' => 'id',
                'value' => $id,
            ));
            break;
        }
    }
}
```
