### PR TITLE
Allow validation for a method without body if an input filter has been specified for that method

### DIFF
--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -186,7 +186,8 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             return;
         }
 
-        $inputFilterService = $this->getInputFilterService($controllerService, $request->getMethod());
+        $method = $request->getMethod();
+        $inputFilterService = $this->getInputFilterService($controllerService, $method);
         if (! $inputFilterService) {
             return;
         }
@@ -209,7 +210,10 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
                 )
             );
         }
-        $data = $dataContainer->getBodyParams();
+
+        $data = in_array($method, $this->methodsWithoutBodies)
+            ? $dataContainer->getQueryParams() : $dataContainer->getBodyParams();
+
         if (null === $data || '' === $data) {
             $data = [];
         }

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -177,11 +177,6 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             return;
         }
 
-        $method = $request->getMethod();
-        if (in_array($method, $this->methodsWithoutBodies)) {
-            return;
-        }
-
         $routeMatches = $e->getRouteMatch();
         if (! $routeMatches instanceof RouteMatch) {
             return;
@@ -191,7 +186,7 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             return;
         }
 
-        $inputFilterService = $this->getInputFilterService($controllerService, $method);
+        $inputFilterService = $this->getInputFilterService($controllerService, $request->getMethod());
         if (! $inputFilterService) {
             return;
         }
@@ -350,6 +345,10 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
     {
         if (isset($this->config[$controllerService][$method])) {
             return $this->config[$controllerService][$method];
+        }
+
+        if (in_array($method, $this->methodsWithoutBodies)) {
+            return false;
         }
 
         if (isset($this->config[$controllerService]['input_filter'])) {

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -254,8 +254,7 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             return $last;
         }
 
-        if($isCollection && in_array($method, $this->methodsWithoutBodies))
-        {
+        if ($isCollection && in_array($method, $this->methodsWithoutBodies)) {
             $data = [$data];
         }
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -254,6 +254,11 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             return $last;
         }
 
+        if($isCollection && in_array($method, $this->methodsWithoutBodies))
+        {
+            $data = [$data];
+        }
+
         $inputFilter->setData($data);
 
         $status = ($request->isPatch())

--- a/test/ContentValidationListenerTest.php
+++ b/test/ContentValidationListenerTest.php
@@ -140,6 +140,10 @@ class ContentValidationListenerTest extends TestCase
 
         $response = $listener->onRoute($event);
         $this->assertInstanceOf('ZF\ApiProblem\ApiProblemResponse', $response);
+        $this->assertNotContains('Value is required and can\'t be empty', $response->getBody());
+        $this->assertContains('The input must contain only digits', $response->getBody());
+        $this->assertContains('The input does not match against pattern \'/^[a-z]+/i\'', $response->getBody());
+
         return $response;
     }
 

--- a/test/ContentValidationListenerTest.php
+++ b/test/ContentValidationListenerTest.php
@@ -97,7 +97,7 @@ class ContentValidationListenerTest extends TestCase
         $this->assertNull($event->getResponse());
     }
 
-    public function testDoesNotReturnEarlyIfRequestMethodWithoutBodyHasInputFilter()
+    public function testReturnsApiProblemResponseIfCollectionRequestWithoutBodyIsInvalid()
     {
         $services = new ServiceManager();
         $factory  = new InputFilterFactory();
@@ -126,6 +126,56 @@ class ContentValidationListenerTest extends TestCase
         $request->setMethod('GET');
 
         $matches = new RouteMatch(['controller' => 'Foo']);
+
+        $dataParams = new ParameterDataContainer();
+        $dataParams->setQueryParams([
+            'foo' => 'abc',
+            'bar' => 123,
+        ]);
+
+        $event   = new MvcEvent();
+        $event->setRequest($request);
+        $event->setRouteMatch($matches);
+        $event->setParam('ZFContentNegotiationParameterData', $dataParams);
+
+        $response = $listener->onRoute($event);
+        $this->assertInstanceOf('ZF\ApiProblem\ApiProblemResponse', $response);
+        $this->assertNotContains('Value is required and can\'t be empty', $response->getBody());
+        $this->assertContains('The input must contain only digits', $response->getBody());
+        $this->assertContains('The input does not match against pattern \'/^[a-z]+/i\'', $response->getBody());
+
+        return $response;
+    }
+
+    public function testReturnsApiProblemResponseIfEntityRequestWithoutBodyIsInvalid()
+    {
+        $services = new ServiceManager();
+        $factory  = new InputFilterFactory();
+        $services->setService('FooValidator', $factory->createInputFilter([
+            'foo' => [
+                'name' => 'foo',
+                'validators' => [
+                    ['name' => 'Digits'],
+                ],
+            ],
+            'bar' => [
+                'name' => 'bar',
+                'validators' => [
+                    [
+                        'name'    => 'Regex',
+                        'options' => ['pattern' => '/^[a-z]+/i'],
+                    ],
+                ],
+            ],
+        ]));
+        $listener = new ContentValidationListener([
+            'Foo' => ['GET' => 'FooValidator'],
+        ], $services, ['Foo' => 'foo_id']);
+
+        $request = new HttpRequest();
+        $request->setMethod('GET');
+
+        $matches = new RouteMatch(['controller' => 'Foo'],['foo_id' => 3]);
 
         $dataParams = new ParameterDataContainer();
         $dataParams->setQueryParams([

--- a/test/ContentValidationListenerTest.php
+++ b/test/ContentValidationListenerTest.php
@@ -175,7 +175,7 @@ class ContentValidationListenerTest extends TestCase
         $request = new HttpRequest();
         $request->setMethod('GET');
 
-        $matches = new RouteMatch(['controller' => 'Foo'],['foo_id' => 3]);
+        $matches = new RouteMatch(['controller' => 'Foo'], ['foo_id' => 3]);
 
         $dataParams = new ParameterDataContainer();
         $dataParams->setQueryParams([


### PR DESCRIPTION
The current implementation of `ContentValidationListener` bails out on validation because `GET ` requests are considered without body and unworthy of validation. However they can have query parameters that can, and perhaps should, be validated. 

*Scenario*
REST Endpoint provides a collection with an optional filter. However the filter has a validation requirement of being at least 3 characters long.  (Searching with fewer than 3 characters is non-performant and non-relevant so we don't allow it).

This pull requests adds the ability to on a case by case basis allow validation on methods not usually validated. Simply specify the input filter for such a method and it will be validated.


```php
[
            'zf-content-validation' => [
                'Application\Controller\HelloWorld' => [
                    'GET' => 'Application\Controller\HelloWorldGet',
                ],
            ],
            'input_filter_specs' => [
                'Application\Controller\HelloWorldGet' => [
                    [
                        'name' => 'name',
                        'required' => true,
                        'filters' => [
                            0 => [
                                'name' => 'Zend\Filter\StringLength',
                                'options' => [
                                    'min' => 3
                                ],
                            ],
                        ],
                        'validators' => [],
                        'description' => 'Hello to name',
                        'allow_empty' => false,
                        'continue_if_empty' => false,
                    ],
                ],
            ]
        ]
```