### PR TITLE
Enable setting use_raw_data = true and allow_only_fields_in_filter = true

### DIFF
--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -279,25 +279,20 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
         //   that was the default experience starting in 1.0.
         // - If the flag is present AND is boolean true, that is also
         //   an indicator that the raw data should be present.
-        if (! isset($this->config[$controllerService]['use_raw_data'])
-            || (isset($this->config[$controllerService]['use_raw_data'])
-                && $this->config[$controllerService]['use_raw_data'] === true)
+        if (!$this->useRawData($controllerService)) {
+            $data = $inputFilter->getValues();
+        }
+
+        // If we don't have an instance of UnknownInputsCapableInterface, or no
+        // unknown data is in the input filter, at this point we can just
+        // set the current data into the data container.
+        if (! $inputFilter instanceof UnknownInputsCapableInterface
+            || ! $inputFilter->hasUnknown()
         ) {
             $dataContainer->setBodyParams($data);
             return;
         }
 
-        // If we don't have an instance of UnknownInputsCapableInterface, or no
-        // unknown data is in the input filter, at this point we can just
-        // set the input filter values directly into the data container.
-        if (! $inputFilter instanceof UnknownInputsCapableInterface
-            || ! $inputFilter->hasUnknown()
-        ) {
-            $dataContainer->setBodyParams($inputFilter->getValues());
-            return;
-        }
-
-        $bodyParams = $inputFilter->getValues();
         $unknown    = $inputFilter->getUnknown();
 
         if ($this->allowsOnlyFieldsInFilter($controllerService)) {
@@ -307,8 +302,7 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
 
             return new ApiProblemResponse($problem);
         }
-
-        $dataContainer->setBodyParams(array_merge($bodyParams, $unknown));
+        $dataContainer->setBodyParams(array_merge($data, $unknown));
     }
 
     /**
@@ -331,6 +325,21 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             return true === $this->config[$controllerService]['allows_only_fields_in_filter'];
         }
 
+        return false;
+    }
+
+    /**
+     * @param $controllerService
+     * @return bool
+     */
+    protected function useRawData($controllerService)
+    {
+        if (! isset($this->config[$controllerService]['use_raw_data'])
+            || (isset($this->config[$controllerService]['use_raw_data'])
+                && $this->config[$controllerService]['use_raw_data'] === true)
+        ) {
+            return true;
+        }
         return false;
     }
 

--- a/test/ContentValidationListenerTest.php
+++ b/test/ContentValidationListenerTest.php
@@ -1309,6 +1309,53 @@ class ContentValidationListenerTest extends TestCase
     }
 
 
+    public function testUseRawAndAllowOnlyFieldsInFilterData()
+    {
+        $services = new ServiceManager();
+        $factory  = new InputFilterFactory();
+        $services->setService('FooFilter', $factory->createInputFilter([
+            'foo' => [
+                'name' => 'foo',
+                'filters' => [
+                    ['name' => 'StringTrim'],
+                ],
+            ],
+        ]));
+        $listener = new ContentValidationListener([
+            'Foo' => [
+                'input_filter' => 'FooFilter',
+                'allows_only_fields_in_filter' => true,
+                'use_raw_data' => true,
+            ],
+        ], $services, [
+            'Foo' => 'foo_id',
+        ]);
+
+        $request = new HttpRequest();
+        $request->setMethod('POST');
+
+        $matches = new RouteMatch(['controller' => 'Foo']);
+
+        $params = [
+            'foo' => ' abc ',
+            'unknown' => 'value'
+        ];
+
+        $dataParams = new ParameterDataContainer();
+        $dataParams->setBodyParams($params);
+
+        $event   = new MvcEvent();
+        $event->setRequest($request);
+        $event->setRouteMatch($matches);
+        $event->setParam('ZFContentNegotiationParameterData', $dataParams);
+
+        /** @var \ZF\ApiProblem\ApiProblemResponse $result */
+        $result = $listener->onRoute($event);
+        $this->assertInstanceOf('ZF\ApiProblem\ApiProblemResponse', $result);
+        $this->assertEquals(422, $result->getApiProblem()->status);
+        $this->assertEquals('Unrecognized fields: unknown', $result->getApiProblem()->detail);
+    }
+
     /**
      * @group 29
      */


### PR DESCRIPTION
This PR enables option compo where you set use_raw_data = true and allow_only_fields_in_filter = true. In other words this would validate that the raw data dosn't contain any key that isn't in the filters. Previously if use_raw_data was true the value of allows_only_fields_in_filter would have been ignored