### PR TITLE
Fix bug where getParam could return falsey values

### DIFF
--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -425,7 +425,7 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
         }
 
         $identifierName = $this->restControllers[$serviceName];
-        if ($matches->getParam($identifierName)) {
+        if ($matches->getParam($identifierName) !== null) {
             return false;
         }
 


### PR DESCRIPTION
- $matches->getParam() can return "0", which evaluates to false
- This fixes that bug by explicity checking against null
- Add test cases