### PR TITLE
Do not merge unknown values when returning raw data

### DIFF
--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -274,7 +274,8 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
         //   that was the default experience starting in 1.0.
         // - If the flag is present AND is boolean true, that is also
         //   an indicator that the raw data should be present.
-        if (! $this->useRawData($controllerService)) {
+        $useRawData = $this->useRawData($controllerService);
+        if (! $useRawData) {
             $data = $inputFilter->getValues();
         }
 
@@ -297,6 +298,16 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
 
             return new ApiProblemResponse($problem);
         }
+
+        // The raw data already contains unknown inputs, so no need to merge
+        // them with the data.
+        if ($useRawData) {
+            $dataContainer->setBodyParams($data);
+            return;
+        }
+
+        // When not using raw data, we merge the unknown data with the
+        // validated data to get the full set of input.
         $dataContainer->setBodyParams(array_merge($data, $unknown));
     }
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -225,16 +225,16 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
 
         $e->setParam('ZF\ContentValidation\InputFilter', $inputFilter);
 
-        $event = clone $e;
-        $event->setName(self::EVENT_BEFORE_VALIDATE);
+        $currentEventName = $e->getName();
+        $e->setName(self::EVENT_BEFORE_VALIDATE);
 
         $events = $this->getEventManager();
-        $e->setName(self::EVENT_BEFORE_VALIDATE);
         $results = $events->triggerEventUntil(function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
         }, $e);
+        $e->setName($currentEventName);
 
         $last = $results->last();
 

--- a/test/ContentValidationListenerTest.php
+++ b/test/ContentValidationListenerTest.php
@@ -1949,7 +1949,7 @@ class ContentValidationListenerTest extends TestCase
         $dataParams = new ParameterDataContainer();
         $dataParams->setBodyParams($params);
 
-        $event   = new MvcEvent();
+        $event = new MvcEvent();
         $event->setRequest($request);
         $event->setRouteMatch($matches);
         $event->setParam('ZFContentNegotiationParameterData', $dataParams);

--- a/test/TestAsset/CustomValidationInputFilter.php
+++ b/test/TestAsset/CustomValidationInputFilter.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\ContentValidation\TestAsset;
+
+use Zend\InputFilter\InputFilter;
+
+class CustomValidationInputFilter extends InputFilter
+{
+    public function isValid()
+    {
+        return true;
+    }
+}

--- a/test/TestAsset/CustomValidationInputFilter.php
+++ b/test/TestAsset/CustomValidationInputFilter.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZFTest\ContentValidation\TestAsset;


### PR DESCRIPTION
We noticed in the zf-apigility-admin when submitting service fields that values were being duplicated (see zfcampus/zf-apigility-admin#345). The reason is because, by default, raw data is used, but a change for the 1.3 release series modified the logic of the content validation listener to no longer return raw data immediately, but to also test that it does not contain unknown fields. In the default use case, when unknown fields are allowed, the unknown fields were being merged back into the data set, causing duplication.

This patch adds a conditional to check if raw data is being used after the check to see if unknown fields are allowed, and, if so, passes the data to the parameter data container and returns immediately, instead of merging.