### PR TITLE
Bug/empty field crash for PATCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#87] (https://github.com/zfcampus/zf-content-validation/issues/87) fixes patch with a 
+blank field name causing a 400 error with a stack trace. It will now issue a 400 error with
+the message 'Unrecognized field ""'
 
 ## 1.3.5 - 2016-08-18
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -470,9 +470,9 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             $inputFilter->setValidationGroup($validationGroup);
             return $inputFilter->isValid();
         } catch (InputFilterInvalidArgumentException $ex) {
-            $pattern = '/expects a list of valid input names; "(?P<field>[^"]+)" was not found/';
+            $pattern = '/expects a list of valid input names; "(?P<field>[^"]*)" was not found/';
             $matched = preg_match($pattern, $ex->getMessage(), $matches);
-            if (! $matched) {
+            if ($matched === 0) {
                 return new ApiProblemResponse(
                     new ApiProblem(400, $ex)
                 );


### PR DESCRIPTION
Fixes a 400 error with a stack trace if the body has a blank field name.

```
{ "": 123 }
```

It will now return a 400 error with the message `'Unrecognized field ""'`