### PR TITLE
Add (usage of) aliases for ContentValidationListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Example:
 
 ### System Configuration
 
-The following configuration is defined by the module in order to function within a ZF2 application.
+The following configuration is defined by the module in order to function within a ZF2/ZF3 application.
 
 ```php
 namespace ZF\ContentValidation;
@@ -178,6 +178,7 @@ return [
             'getinputfilter' => InputFilter\InputFilterPlugin::class,
             'getInputfilter' => InputFilter\InputFilterPlugin::class,
             'getInputFilter' => InputFilter\InputFilterPlugin::class,
+            'GetInputFilter' => InputFilter\InputFilterPlugin::class,
         ],
         'factories' => [
             InputFilter\InputFilterPlugin::class => InvokableFactory::class,
@@ -189,6 +190,11 @@ return [
         ],
     ],
     'service_manager' => [
+        'aliases' => [
+            'contentvalidationlistener' => ContentValidationListener::class,
+            'contentValidationListener' => ContentValidationListener::class,
+            'ContentValidationListener' => ContentValidationListener::class,
+        ],
         'factories' => [
             ContentValidationListener::class => ContentValidationListenerFactory::class,
         ],

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -15,6 +15,7 @@ return [
             'getinputfilter' => InputFilter\InputFilterPlugin::class,
             'getInputfilter' => InputFilter\InputFilterPlugin::class,
             'getInputFilter' => InputFilter\InputFilterPlugin::class,
+            'GetInputFilter' => InputFilter\InputFilterPlugin::class,
         ],
         'factories' => [
             InputFilter\InputFilterPlugin::class => InvokableFactory::class,
@@ -37,6 +38,11 @@ return [
         ],
     ],
     'service_manager' => [
+        'aliases' => [
+            'contentvalidationlistener' => ContentValidationListener::class,
+            'contentValidationListener' => ContentValidationListener::class,
+            'ContentValidationListener' => ContentValidationListener::class,
+        ],
         'factories' => [
             ContentValidationListener::class => ContentValidationListenerFactory::class,
         ],

--- a/src/Module.php
+++ b/src/Module.php
@@ -21,6 +21,6 @@ class Module
         $events   = $app->getEventManager();
         $services = $app->getServiceManager();
 
-        $services->get(ContentValidationListener::class)->attach($events);
+        $services->get('ContentValidationListener')->attach($events);
     }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?

Usage of an alias allows users to provide own implementation of ContentValidationListener

  - [x] How will users use the new feature?

Users might wish to add/remove/alter ContentValidationListener implementation (like me :) )

  - [x] Base your feature on the `develop` branch, and submit against that branch.

Done

  - [x] Add only one feature per pull request; split multiple features over multiple pull requests

Done -> Adding aliases. Implementing single usage of aliases in Module.php.

  - [-] Add tests for the new feature.

Not a feature, no change in functionality.

  - [x] Add documentation for the new feature.

Updated with changes

  - [-] Add a `CHANGELOG.md` entry for the new feature.

Not a feature, just expanding and making optional which one to use, without modification of current implementation. **Would this require changelog entry?**
