### PR TITLE
Remove empty data after filtering in onRoute - option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Added `remove_empty_data` flag - If set & true it causes removal of empty key/value pairs from filtered input data.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Added `remove_empty_data` flag - If set & true it causes removal of empty key/value pairs from filtered input data.
+- [#102](https://github.com/zfcampus/zf-content-validation/pull/102) adds the configuration flag `remove_empty_data`. If set and boolean 
+  `true`, it causes removal of empty key/value pairs from filtered input data.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ behavior:
 - `allows_only_fields_in_filter`: if present, and `use_raw_data` is boolean false, the value of this
   flag will define whether or not additional fields present in the payload will be merged with the
   filtered data.
+  
+- `remove_empty_data`: Should we remove empty data from received data?
+  - If no `remove_empty_data` flag is present, do nothing - use data as is
+  - If `remove_empty_data` flag is present AND is boolean true, then remove
+    empty data from current data array
 
 > ### Validating GET requests
 >

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ behavior:
   - If no `remove_empty_data` flag is present, do nothing - use data as is
   - If `remove_empty_data` flag is present AND is boolean true, then remove
     empty data from current data array
+  - Does not remove empty data if keys matched received data
 
 > ### Validating GET requests
 >

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -78,6 +78,11 @@ return [
          *   boolean false, the value of this flag will define whether or
          *   not additional fields present in the payload will be merged
          *   with the filtered data.
+         *
+         * - remove_empty_data: Should we remove empty data from received data?
+         *   - If no `remove_empty_data` flag is present, do nothing - use data as is
+         *   - If `remove_empty_data` flag is present AND is boolean true, then remove
+         *     empty data from current data array
          */
     ],
 ];

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -395,13 +395,13 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
     {
         /**
          * @todo strict return type
+         * Callback for array_filter() to remove null values (array_filter() removes 'false' values)
          *
          * @param       $value
          * @param null  $key
          *
          * @return bool
          */
-        // Callback for array_filter() to remove null values (array_filter() removes 'false' values)
         $removeNull = function ($value, $key = null) use ($compareTo) {
             // If comparison array is empty, do a straight comparison
             if (empty($compareTo)) {

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -393,7 +393,7 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
     protected function removeEmptyData($data, $compareTo = [])
     {
         // TODO when bumped to PHP > 7 and strict types above enforced this check may be removed
-        if ( ! is_array($data) || ! is_array($compareTo)) {
+        if (! is_array($data) || ! is_array($compareTo)) {
             throw new TypeError(
                 sprintf(
                     'Expected array\'s for function %s. Received "%s" and "%s".',
@@ -428,11 +428,11 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
         }
 
         foreach ($data as $key => $value) {
-            if ( ! is_array($value) && ! empty($value)) {
+            if (! is_array($value) && ! empty($value)) {
                 continue;
             }
 
-            if ( ! is_array($value)) {
+            if (! is_array($value)) {
                 unset($data[$key]);
                 continue;
             }

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -428,7 +428,9 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
         }
 
         foreach ($data as $key => $value) {
-            if (! is_array($value) && ! empty($value)) {
+            if (! is_array($value)
+                && (! empty($value) || (is_bool($value)) && ! in_array($key, $compareTo))
+            ) {
                 continue;
             }
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -397,27 +397,28 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
         }
 
         foreach ($data as $key => $value) {
-            if (is_array($value)) {
-                if (empty(array_filter($value, $removeNull))) {
-                    unset($data[$key]);
-                } else {
-                    $tmpValue = $this->removeEmptyData($value);
-
-                    // Additional check to ensure it's not an empty recursive result
-                    if (empty(array_filter($tmpValue, $removeNull))) {
-                        unset($data[$key]);
-                    } else {
-                        $data[$key] = $tmpValue;
-                    }
-
-                    // Destroy var so it's not accidentally used on a next iteration
-                    unset($tmpValue);
-                }
-            } else {
-                if (empty($value)) {
-                    unset($data[$key]);
-                }
+            if ( ! is_array($value) && ! empty($value)) {
+                continue;
             }
+
+            if ( ! is_array($value)) {
+                unset($data[$key]);
+                continue;
+            }
+
+            if (empty(array_filter($value, $removeNull))) {
+                unset($data[$key]);
+                continue;
+            }
+
+            $tmpValue = $this->removeEmptyData($value);
+            // Additional check to ensure it's not an empty recursive result
+            if (empty(array_filter($tmpValue, $removeNull))) {
+                unset($data[$key]);
+                continue;
+            }
+
+            $data[$key] = $tmpValue;
         }
 
         return $data;

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -375,10 +375,8 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             || (isset($this->config[$controllerService]['remove_empty_data'])
                 && $this->config[$controllerService]['remove_empty_data'] === true)
         ) {
-
             return true;
         }
-
         return false;
     }
 
@@ -390,7 +388,6 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
     {
         $data = array_filter($data);
         if (empty($data)) {
-
             return $data;
         }
 
@@ -407,7 +404,6 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
                 }
             }
         }
-
         return $data;
     }
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -6,7 +6,6 @@
 
 namespace ZF\ContentValidation;
 
-use TypeError;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
@@ -368,14 +367,13 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
     }
 
     /**
-     * @param $controllerService
+     * @param string $controllerService
      * @return bool
      */
     protected function shouldRemoveEmptyData($controllerService)
     {
         if (! isset($this->config[$controllerService]['remove_empty_data'])
-            || (isset($this->config[$controllerService]['remove_empty_data'])
-                && $this->config[$controllerService]['remove_empty_data'] === true)
+            || $this->config[$controllerService]['remove_empty_data'] === true
         ) {
             return true;
         }
@@ -383,23 +381,18 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
     }
 
     /**
-     * @todo strict types for PHP > 7 when module gets bumped
-     *       protected function removeEmptyData(array $data, array $compareTo = []) : array
-     *
      * @param array $data Data to filter null values from
-     * @param array $compareTo Original data, send along to preserve keys/values in $data which are intentional
-     *
+     * @param array $compareTo Original data, send along to preserve
+     *     keys/values in $data which are intentional
      * @return array
      */
-    protected function removeEmptyData(array $data, $compareTo = [])
+    protected function removeEmptyData(array $data, array $compareTo = [])
     {
         /**
-         * @todo strict return type
          * Callback for array_filter() to remove null values (array_filter() removes 'false' values)
          *
-         * @param       $value
+         * @param mixed $value
          * @param null  $key
-         *
          * @return bool
          */
         $removeNull = function ($value, $key = null) use ($compareTo) {
@@ -424,7 +417,7 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
 
         foreach ($data as $key => $value) {
             if (! is_array($value)
-                && (! empty($value) || (is_bool($value)) && ! in_array($key, $compareTo))
+                && (! empty($value) || is_bool($value) && ! in_array($key, $compareTo))
             ) {
                 continue;
             }
@@ -439,7 +432,7 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
                 continue;
             }
 
-            $tmpValue = (array_key_exists($key, $compareTo) && is_array($compareTo[$key]))
+            $tmpValue = array_key_exists($key, $compareTo) && is_array($compareTo[$key])
                 ? $this->removeEmptyData($value, $compareTo[$key])
                 : $this->removeEmptyData($value);
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -383,34 +383,29 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
     }
 
     /**
+     * @todo strict types for PHP > 7 when module gets bumped
+     *       protected function removeEmptyData(array $data, array $compareTo = []) : array
+     *
      * @param array $data Data to filter null values from
      * @param array $compareTo Original data, send along to preserve keys/values in $data which are intentional
      *
      * @return array
      */
-    // TODO strict types for PHP > 7 when module gets bumped
-    //    protected function removeEmptyData(array $data, array $compareTo = []) : array
-    protected function removeEmptyData($data, $compareTo = [])
+    protected function removeEmptyData(array $data, $compareTo = [])
     {
-        // TODO when bumped to PHP > 7 and strict types above enforced this check may be removed
-        if (! is_array($data) || ! is_array($compareTo)) {
-            throw new TypeError(
-                sprintf(
-                    'Expected array\'s for function %s. Received "%s" and "%s".',
-                    __METHOD__,
-                    gettype($data),
-                    gettype($compareTo)
-                ),
-                500,
-                __FILE__
-            );
-        }
-
+        /**
+         * @todo strict return type
+         *
+         * @param       $value
+         * @param null  $key
+         *
+         * @return bool
+         */
         // Callback for array_filter() to remove null values (array_filter() removes 'false' values)
         $removeNull = function ($value, $key = null) use ($compareTo) {
             // If comparison array is empty, do a straight comparison
             if (empty($compareTo)) {
-                return ! is_null($value);
+                return null !== $value;
             }
 
             // If key exists in comparison array, the 'null' value is on purpose, leave as is
@@ -418,7 +413,7 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
                 return true;
             }
 
-            return ! is_null($value);
+            return null !== $value;
         };
 
         $data = array_filter($data, $removeNull, ARRAY_FILTER_USE_BOTH);
@@ -444,11 +439,9 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
                 continue;
             }
 
-            if (array_key_exists($key, $compareTo) && is_array($compareTo[$key])) {
-                $tmpValue = $this->removeEmptyData($value, $compareTo[$key]);
-            } else {
-                $tmpValue = $this->removeEmptyData($value);
-            }
+            $tmpValue = (array_key_exists($key, $compareTo) && is_array($compareTo[$key]))
+                ? $this->removeEmptyData($value, $compareTo[$key])
+                : $this->removeEmptyData($value);
 
             // Additional check to ensure it's not an empty recursive result
             if (empty(array_filter($tmpValue, $removeNull, ARRAY_FILTER_USE_BOTH))) {

--- a/test/ContentValidationListenerTest.php
+++ b/test/ContentValidationListenerTest.php
@@ -2098,9 +2098,7 @@ class ContentValidationListenerTest extends TestCase
 
     /**
      * @group 40 removeEmptyData
-     *
      * @param array $eventParams
-     *
      * @return MvcEvent
      */
     public function createGroup40Event(array $eventParams)
@@ -2123,50 +2121,45 @@ class ContentValidationListenerTest extends TestCase
 
     /**
      * @group 40 removeEmptyData
-     *
      * @return ContentValidationListener
      */
     public function createGroup40Listener()
     {
         $factory = new InputFilterFactory();
 
-        $inputFilterA = $factory->createInputFilter(
+        $inputFilterA = $factory->createInputFilter([
             [
-                [
-                    'name'     => 'foo',
-                    'required' => true,
-                    'filters'  => [
-                        ['name' => StringTrim::class],
-                    ],
+                'name'     => 'foo',
+                'required' => true,
+                'filters'  => [
+                    ['name' => StringTrim::class],
                 ],
-                [
-                    'name'     => 'bar',
-                    'required' => false,
-                    'filters'  => [
-                        ['name' => StringTrim::class],
-                    ],
+            ],
+            [
+                'name'     => 'bar',
+                'required' => false,
+                'filters'  => [
+                    ['name' => StringTrim::class],
                 ],
-                [
-                    'name'     => 'empty',
-                    'required' => false,
-                    'filters'  => [
-                        ['name' => StringTrim::class],
-                    ],
+            ],
+            [
+                'name'     => 'empty',
+                'required' => false,
+                'filters'  => [
+                    ['name' => StringTrim::class],
                 ],
-            ]
-        );
+            ],
+        ]);
 
-        $inputFilterB = $factory->createInputFilter(
+        $inputFilterB = $factory->createInputFilter([
             [
-                [
-                    'name'     => 'empty_field',
-                    'required' => false,
-                    'filters'  => [
-                        ['name' => StringTrim::class],
-                    ],
+                'name'     => 'empty_field',
+                'required' => false,
+                'filters'  => [
+                    ['name' => StringTrim::class],
                 ],
-            ]
-        );
+            ],
+        ]);
 
         $inputFilterA->add($inputFilterB, 'empty_array');
 
@@ -2190,8 +2183,6 @@ class ContentValidationListenerTest extends TestCase
     }
 
     /**
-     * @group 40 removeEmptyData
-     *
      * Flows:
      * 1 - data is empty, return immediately
      * 2 - loop key/value - value (is not an array and (not empty or (is a boolean & not in comparison array)))
@@ -2200,6 +2191,8 @@ class ContentValidationListenerTest extends TestCase
      * 5 - value is an array containing recursive data (subject to 1 through 4)
      *
      * This test does #1
+     *
+     * @group 40 removeEmptyData
      */
     public function testFilterEmptyEntriesFromDataByOptionWhenDataEmpty()
     {
@@ -2215,9 +2208,13 @@ class ContentValidationListenerTest extends TestCase
         );
     }
 
+    public function booleanProvider()
+    {
+        yield 'true'  => [true];
+        yield 'false' => [false];
+    }
+
     /**
-     * @group 40 removeEmptyData
-     *
      * Flows:
      * 1 - data is empty, return immediately
      * 2 - loop key/value - value (is not an array and (not empty or (is a boolean & not in comparison array)))
@@ -2226,45 +2223,29 @@ class ContentValidationListenerTest extends TestCase
      * 5 - value is an array containing recursive data (subject to 1 through 4)
      *
      * This test does #2 (twice, once for 'true', once for 'false')
+     *
+     * @group 40 removeEmptyData
+     * @dataProvider booleanProvider
+     * @param bool $value
      */
-    public function testFilterEmptyEntriesFromDataByOptionWhenValueBooleanNotInComparison()
+    public function testFilterEmptyEntriesFromDataByOptionWhenValueBooleanNotInComparison($value)
     {
-        $event = $this->createGroup40Event(
-            [
-                'foo' => true,
-            ]
-        );
+        $event = $this->createGroup40Event([
+            'foo' => $value,
+        ]);
 
         $listener = $this->createGroup40Listener();
         $listener->onRoute($event);
 
         $this->assertEquals(
             [
-                'foo' => true,
+                'foo' => $value,
             ],
             $event->getParam('ZFContentNegotiationParameterData')->getBodyParams()
-        );
-
-        $event2 = $this->createGroup40Event(
-            [
-                'foo' => false,
-            ]
-        );
-
-        $listener2 = $this->createGroup40Listener();
-        $listener2->onRoute($event2);
-
-        $this->assertEquals(
-            [
-                'foo' => false,
-            ],
-            $event2->getParam('ZFContentNegotiationParameterData')->getBodyParams()
         );
     }
 
     /**
-     * @group 40 removeEmptyData
-     *
      * Flows:
      * 1 - data is empty, return immediately
      * 2 - loop key/value - value (is not an array and (not empty or (is a boolean & not in comparison array)))
@@ -2273,14 +2254,14 @@ class ContentValidationListenerTest extends TestCase
      * 5 - value is an array containing recursive data (subject to 1 through 4)
      *
      * This test does #3
+     *
+     * @group 40 removeEmptyData
      */
     public function testFilterEmptyEntriesFromDataByOptionWhenValueNotAnArray()
     {
-        $event = $this->createGroup40Event(
-            [
-                'foo' => ' string ',
-            ]
-        );
+        $event = $this->createGroup40Event([
+            'foo' => ' string ',
+        ]);
 
         $listener = $this->createGroup40Listener();
         $listener->onRoute($event);
@@ -2294,8 +2275,6 @@ class ContentValidationListenerTest extends TestCase
     }
 
     /**
-     * @group 40 removeEmptyData
-     *
      * Flows:
      * 1 - data is empty, return immediately
      * 2 - loop key/value - value (is not an array and (not empty or (is a boolean & not in comparison array)))
@@ -2304,16 +2283,16 @@ class ContentValidationListenerTest extends TestCase
      * 5 - value is an array containing recursive data (subject to 1 through 4)
      *
      * This test does #4
+     *
+     * @group 40 removeEmptyData
      */
     public function testFilterEmptyEntriesFromDataByOptionWhenValueEmptyAfterFilter()
     {
-        $event = $this->createGroup40Event(
-            [
-                'foo' => [
-                    'test' => []
-                ],
-            ]
-        );
+        $event = $this->createGroup40Event([
+            'foo' => [
+                'test' => [],
+            ],
+        ]);
 
         $listener = $this->createGroup40Listener();
         $listener->onRoute($event);
@@ -2325,8 +2304,6 @@ class ContentValidationListenerTest extends TestCase
     }
 
     /**
-     * @group 40 removeEmptyData
-     *
      * Flows:
      * 1 - data is empty, return immediately
      * 2 - loop key/value - value (is not an array and (not empty or (is a boolean & not in comparison array)))
@@ -2335,18 +2312,18 @@ class ContentValidationListenerTest extends TestCase
      * 5 - value is an array containing recursive data (subject to 1 through 4)
      *
      * This test does #5
+     *
+     * @group 40 removeEmptyData
      */
     public function testFilterEmptyEntriesFromDataByOptionWithNestedData()
     {
-        $event = $this->createGroup40Event(
-            [
-                'foo'         => ' abc ',
-                'empty'       => null,
-                'empty_array' => [
-                    'empty_field' => null,
-                ],
-            ]
-        );
+        $event = $this->createGroup40Event([
+            'foo'         => ' abc ',
+            'empty'       => null,
+            'empty_array' => [
+                'empty_field' => null,
+            ],
+        ]);
 
         $listener = $this->createGroup40Listener();
 


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?

Issue #59 - When *not* using raw data (so filtered) and having requirements on the Entities (logically), the issue can exist that `null` values get attempted to be hydrated. 

Filtering the data (by *not* using raw data), causes all keys for of all InputFilter's to be added to the data array which gets passed to the `DoctrineObject` hydrator in the current happy flow. 

This PR gives an additional option: filter out the null values. 

  - [x] How will users use the new feature?

Same as `use_raw_data` and `allows_only_fields_in_filter` -> create config key with `true` value.

  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.

---

**Acceptance criteria**

- [x] Provide config flag to filter out null values
- [x] Filter out null values when flag set to `true` 
- [x] Do not filter out null values from request (received) data, this is intentionally send and might be intended for optional value

---

This may not be the greatest solution, I'm open to suggestions/requests for improvement. 

However, consider that this added bit does not change the current implementation, it just adds the possibility to filter out the null/empty values of a received data array. 

It does not contain a bc-break as it must be enabled with config, the same way as 2 existing options.
