### PR TITLE
Hotfix #104 - when remove_empty_data is not set - do nothing, use data as is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#105](https://github.com/zfcampus/zf-content-validation/pull/105) fixes default behaviour when the configuration
+  flag `remove_empty_data` is not set. Data are not changed as described in the documentation.
+  It fixes BC Break introduced in version 1.7.0.
 
 ## 1.7.0 - 2019-02-26
 

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -372,8 +372,8 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
      */
     protected function shouldRemoveEmptyData($controllerService)
     {
-        if (! isset($this->config[$controllerService]['remove_empty_data'])
-            || $this->config[$controllerService]['remove_empty_data'] === true
+        if (isset($this->config[$controllerService]['remove_empty_data'])
+            && $this->config[$controllerService]['remove_empty_data'] === true
         ) {
             return true;
         }


### PR DESCRIPTION
According to the documentation data should not be changed when the
configuration option is not provided. It is to keep BC.

Fixes #104

- [X] Are you fixing a bug?
  - [X] Detail how the bug is invoked currently.
  - [X] Detail the original, incorrect behavior.
  - [X] Detail the new, expected behavior.
  - [X] Base your feature on the `master` branch, and submit against that branch.
  - [X] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

/cc @babarizbak @rkeet